### PR TITLE
FIX: DeprecationWarning - picx/db

### DIFF
--- a/picx-db/index.js
+++ b/picx-db/index.js
@@ -14,7 +14,7 @@ if (!config.db) {
   process.exit(1)
 }
 
-mongoose.connect(config.db)
+mongoose.connect(config.db, { useNewUrlParser: true })
 mongoose.connection.on('error', terminate(1, 'dbError'))
 mongoose.connection.once('open', () => {
   log.info('db connected')


### PR DESCRIPTION
(node:49344) DeprecationWarning: current URL string parser is deprecated, and
will be removed in a future version. To use the new parser, pass option
{ useNewUrlParser: true } to MongoClient.connect.