### PR TITLE
run docker with picx user and fix deprecation about url string parser

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,23 @@
 FROM node:10
 
+# Add User picx
+RUN groupadd -g 999 picx && useradd -r -u 999 -g picx picx
+
 WORKDIR /usr/src/app
+RUN chown -R picx:picx /usr/src/app
 
 # Add Tini Support
 ENV TINI_VERSION v0.18.0
 ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /tini
+RUN chown -R picx:picx /tini
 RUN chmod +x /tini
 
 # Move and Install project
 COPY . .
 RUN npm install --production
+
+# User
+USER picx
 
 EXPOSE 8000
 ENTRYPOINT [ "/tini", "--" ]

--- a/picx-db/index.js
+++ b/picx-db/index.js
@@ -14,7 +14,7 @@ if (!config.db) {
   process.exit(1)
 }
 
-mongoose.connect(config.db)
+mongoose.connect(config.db, { useNewUrlParser: true })
 mongoose.connection.on('error', terminate(1, 'dbError'))
 mongoose.connection.once('open', () => {
   log.info('db connected')


### PR DESCRIPTION
Following the Dockerfile Best Practices, I have created an user called **picx** rather than run it with user **root**. Also, I fixed the deprecation warning about *url string parser* on `mongoose.connect` at `@picx-db/index.js`.